### PR TITLE
ASM-3157 For SCVMM cluster provisioning AD must not contain any hosts  with same name

### DIFF
--- a/lib/puppet/provider/computer_account/default.rb
+++ b/lib/puppet/provider/computer_account/default.rb
@@ -24,7 +24,7 @@ Puppet::Type.type(:computer_account).provide(:default, :parent => Puppet::Provid
   end
 
   def destroy
-    command = "dsrm.exe -q -noprompt #{@result}"
+    command = "dsrm.exe -q -noprompt -subtree #{@result}"
     winrm_ps(command)
   end
 


### PR DESCRIPTION
In case there is any dependency on the AD name, the cleanup of the AD entries needs to be done with skipping the dependent AD entries.